### PR TITLE
register choice, save schema registry to cache

### DIFF
--- a/lib/avro_turf/cached_schema_registry.rb
+++ b/lib/avro_turf/cached_schema_registry.rb
@@ -3,10 +3,11 @@ require 'avro_turf/schema_registry'
 # Caches registrations and lookups to the schema registry in memory.
 class AvroTurf::CachedSchemaRegistry
 
-  def initialize(upstream)
+  def initialize(upstream, register: true)
     @upstream = upstream
     @schemas_by_id = {}
     @ids_by_schema = {}
+    @register = register
   end
 
   # Delegate the following methods to the upstream
@@ -21,6 +22,15 @@ class AvroTurf::CachedSchemaRegistry
   end
 
   def register(subject, schema)
-    @ids_by_schema[subject + schema.to_s] ||= @upstream.register(subject, schema)
+    @ids_by_schema[subject + schema.to_s] ||= upstream_register(subject, schema)
+  end
+
+  def upstream_register(subject, schema)
+    @upstream.register(subject, schema) if @register
+  end
+
+  def store!(subject, schema, id)
+    @schemas_by_id[id] = schema.to_s
+    @ids_by_schema[subject + schema.to_s] = id
   end
 end

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -16,18 +16,18 @@ class AvroTurf
   # 1: https://github.com/confluentinc/schema-registry
   class Messaging
     MAGIC_BYTE = [0].pack("C").freeze
-
     # Instantiate a new Messaging instance with the given configuration.
     #
     # registry_url - The String URL of the schema registry that should be used.
     # schemas_path - The String file system path where local schemas are stored.
     # namespace    - The String default schema namespace.
     # logger       - The Logger that should be used to log information (optional).
-    def initialize(registry_url: nil, schemas_path: nil, namespace: nil, logger: nil)
+    # register     - The Boolean for wheather or not to register new schemas  (optional).
+    def initialize(registry_url: nil, schemas_path: nil, namespace: nil, logger: nil, register: true)
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
       @schema_store = SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH)
-      @registry = CachedSchemaRegistry.new(SchemaRegistry.new(registry_url, logger: @logger))
+      @registry = CachedSchemaRegistry.new(SchemaRegistry.new(registry_url, logger: @logger), register: register)
     end
 
     # Encodes a message using the specified schema.
@@ -37,15 +37,21 @@ class AvroTurf
     # schema_name - The String name of the schema that should be used to encode
     #               the data.
     # namespace   - The namespace of the schema (optional).
+    # version     - specifc a specific verision of a schema (optional).
     #
     # Returns the encoded data as a String.
-    def encode(message, schema_name: nil, namespace: @namespace)
-      schema = @schema_store.find(schema_name, namespace)
-
-      # Schemas are registered under the full name of the top level Avro record
-      # type.
-      schema_id = @registry.register(schema.fullname, schema)
-
+    def encode(message, schema_name: nil, namespace: @namespace, version: 'latest')
+      begin
+        schema = @schema_store.find(schema_name, namespace)
+        # Schemas are registered under the full name of the top level Avro
+        # record type.
+        schema_id = @registry.register(schema.fullname, schema)
+      rescue => e
+        @logger.info("Looking for schema: #{schema_name} at schema registry")
+        # Check rest proxy for it
+        schema_json = @registry.subject_version(schema_name, version)
+        schema, schema_id = register_found_schema(schema_json, schema_name)
+      end
       stream = StringIO.new
       writer = Avro::IO::DatumWriter.new(schema)
       encoder = Avro::IO::BinaryEncoder.new(stream)
@@ -55,7 +61,6 @@ class AvroTurf
 
       # The schema id is encoded as a 4-byte big-endian integer.
       encoder.write([schema_id].pack("N"))
-
       # The actual message comes last.
       writer.write(message, encoder)
 
@@ -90,6 +95,16 @@ class AvroTurf
 
       reader = Avro::IO::DatumReader.new(writers_schema, readers_schema)
       reader.read(decoder)
+    end
+
+    private
+
+    def register_found_schema(schema_json, schema_name)
+      fail 'No schema found' if schema_json.nil?
+      schema = Avro::Schema.parse(schema_json['schema'])
+      @schema_store.store!(schema.fullname, schema)
+      @registry.store!(schema.fullname, schema, schema_json['id'])
+      return schema, schema_json['id']
     end
   end
 end

--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -55,4 +55,8 @@ class AvroTurf::SchemaStore
       find(schema_name)
     end
   end
+
+  def store!(full_name, schema)
+    @schemas[full_name] = schema
+  end
 end

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -6,74 +6,176 @@ describe AvroTurf::Messaging do
   let(:registry_url) { "http://registry.example.com" }
   let(:logger) { Logger.new(StringIO.new) }
 
-  let(:avro) {
-    AvroTurf::Messaging.new(
-      registry_url: registry_url,
-      schemas_path: "spec/schemas",
-      logger: logger
-    )
-  }
+  describe 'local' do
+    let(:avro) {
+      AvroTurf::Messaging.new(
+        registry_url: registry_url,
+        schemas_path: "spec/schemas",
+        logger: logger
+      )
+    }
 
-  before do
-    FileUtils.mkdir_p("spec/schemas")
-  end
+    before do
+      FileUtils.mkdir_p("spec/schemas")
+    end
 
-  before do
-    stub_request(:any, /^#{registry_url}/).to_rack(FakeSchemaRegistryServer)
-    FakeSchemaRegistryServer.clear
-  end
+    before do
+      stub_request(:any, /^#{registry_url}/).to_rack(FakeSchemaRegistryServer)
+      FakeSchemaRegistryServer.clear
+    end
 
-  before do
-    define_schema "person.avsc", <<-AVSC
-      {
-        "name": "person",
-        "type": "record",
-        "fields": [
-          {
-            "type": "string",
-            "name": "full_name"
-          }
-        ]
-      }
-    AVSC
-  end
-
-  it "encodes and decodes messages" do
-    message = { "full_name" => "John Doe" }
-    data = avro.encode(message, schema_name: "person")
-    expect(avro.decode(data)).to eq message
-  end
-
-  it "allows specifying a reader's schema" do
-    message = { "full_name" => "John Doe" }
-    data = avro.encode(message, schema_name: "person")
-    expect(avro.decode(data, schema_name: "person")).to eq message
-  end
-
-  context "when active_support/core_ext is present" do
-    let(:avro) do
-      super().tap do |messaging|
-        # Simulate the presence of active_support/core_ext by monkey patching
-        # the schema store to monkey patch #to_json on the returned schema.
-        schema_store = messaging.instance_variable_get(:@schema_store)
-        def schema_store.find(*)
-          super.extend(Module.new do
-            # Replace to_json on the returned schema with an implementation
-            # that returns something similar to active_support/core_ext/json
-            def to_json(*args)
-              instance_variables.each_with_object(Hash.new) do |ivar, result|
-                result[ivar.to_s.sub('@','')] = instance_variable_get(ivar)
-              end.to_json(*args)
-            end
-          end)
-        end
-      end
+    before do
+      define_schema "person.avsc", <<-AVSC
+        {
+          "name": "person",
+          "type": "record",
+          "fields": [
+            {
+              "type": "string",
+              "name": "full_name"
+            }
+          ]
+        }
+      AVSC
     end
 
     it "encodes and decodes messages" do
       message = { "full_name" => "John Doe" }
       data = avro.encode(message, schema_name: "person")
       expect(avro.decode(data)).to eq message
+    end
+
+    it "allows specifying a reader's schema" do
+      message = { "full_name" => "John Doe" }
+      data = avro.encode(message, schema_name: "person")
+      expect(avro.decode(data, schema_name: "person")).to eq message
+    end
+
+    context "when active_support/core_ext is present" do
+      let(:avro) do
+        super().tap do |messaging|
+          # Simulate the presence of active_support/core_ext by monkey patching
+          # the schema store to monkey patch #to_json on the returned schema.
+          schema_store = messaging.instance_variable_get(:@schema_store)
+          def schema_store.find(*)
+            super.extend(Module.new do
+              # Replace to_json on the returned schema with an implementation
+              # that returns something similar to active_support/core_ext/json
+              def to_json(*args)
+                instance_variables.each_with_object(Hash.new) do |ivar, result|
+                  result[ivar.to_s.sub('@','')] = instance_variable_get(ivar)
+                end.to_json(*args)
+              end
+            end)
+          end
+        end
+      end
+
+      it "encodes and decodes messages" do
+        message = { "full_name" => "John Doe" }
+        data = avro.encode(message, schema_name: "person")
+        expect(avro.decode(data)).to eq message
+      end
+    end
+  end # local
+
+  describe 'register from rest proxy' do
+    let(:avro) do
+      AvroTurf::Messaging.new(
+        registry_url: registry_url,
+        logger: logger,
+        register: false
+      )
+    end
+
+    let :schema do
+      {
+        'subject' => 'person',
+        'version' => 1,
+        'id' => 3,
+        'schema' => {
+          type: 'record',
+          name: 'person',
+          namespace: 'namespace',
+          fields: [{ name: 'full_name', type: 'string' }]
+        }.to_json
+      }
+    end
+
+    before :each do
+      stub_request(:get, "#{registry_url}/subjects/person/versions/latest")
+        .to_return(status: 200, body: schema.to_json)
+      # stub_request(:get, "#{registry_url}/schemas/ids/#{schema[:id]}")
+        # .to_return(status: 200, body: schema.to_json)
+    end
+
+    it 'loads from schema resgitry' do
+      message = { "full_name" => "John Doe" }
+      expect(avro).to receive(:register_found_schema).with(schema, 'person')
+        .and_return([Avro::Schema.parse(schema['schema']), schema['id']])
+      data = avro.encode(message, schema_name: "person")
+
+      sch = Avro::Schema.parse(schema['schema'])
+      schema_store = avro.instance_variable_get(:@schema_store)
+      registry = avro.instance_variable_get(:@registry)
+      schema_store.store!(sch.fullname, sch)
+      registry.store!(sch.fullname, sch, schema['id'])
+      expect(avro.decode(data, schema_name: 'person', namespace: 'namespace')).to eq message
+    end
+
+    it 'already exists in cache' do
+      # Register the schema
+      sch, id = avro.send(:register_found_schema, schema, 'person')
+
+      message = { "full_name" => "John Doe" }
+      expect(avro).to_not receive(:register_found_schema).with(schema, 'person')
+      data = avro.encode(message, schema_name: "person", namespace: 'namespace')
+      expect(avro.decode(data, schema_name: 'person', namespace: 'namespace')).to eq message
+    end
+  end
+
+  describe 'register_found_schema' do
+    let(:avro) do
+      AvroTurf::Messaging.new(
+        registry_url: registry_url,
+        logger: logger,
+        register: false
+      )
+    end
+
+    let :schema do
+      {
+        'subject' => 'person',
+        'version' => 1,
+        'id' => 3,
+        'schema' => {
+          type: 'record',
+          name: 'person',
+          namespace: 'namespace',
+          fields: [{ name: 'full_name', type: 'string' }]
+        }.to_json
+      }
+    end
+
+    it 'fails without a schema' do
+      expect do
+        avro.send(:register_found_schema, nil, 'person')
+      end.to raise_error RuntimeError
+    end
+
+    it 'stores the schema' do
+      sch, id = avro.send(:register_found_schema, schema, 'person')
+      expect(sch).to eq Avro::Schema.parse(schema['schema'])
+      expect(id).to eq schema['id']
+      store = avro.instance_variable_get(:@schema_store)
+      registry = avro.instance_variable_get(:@registry)
+      schemas = { sch.fullname => sch }
+      schemas_by_ids = { schema['id'] => sch.to_s }
+      ids_by_schema = { sch.fullname + schema['schema'] => schema['id'] }
+
+      expect(store.instance_variable_get(:@schemas)).to eq schemas
+      expect(registry.instance_variable_get(:@schemas_by_id)).to eq schemas_by_ids
+      expect(registry.instance_variable_get(:@ids_by_schema)).to eq ids_by_schema
     end
   end
 end


### PR DESCRIPTION
**Motivation behind this PR**
- Add a way to turn on/off registering of new schemas
- Cache schemas found by the schemas

**Use Case**
Using the Confluent Schema Registry. We register our schemas in a separate task. We want to be able to specify the schema and a version to encode/decode with. This PR will allow schemas to be only defined in the schema registry. Once you look for the schema and find it in _not_ local it will go to the registry look for that and store it in cache as before.
